### PR TITLE
feat: Add Calendar View for Projects and Tasks

### DIFF
--- a/__tests__/components/calendar-view.test.tsx
+++ b/__tests__/components/calendar-view.test.tsx
@@ -1,0 +1,241 @@
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { CalendarView } from "@/components/calendar-view";
+import { Project } from "@/lib/projects/types";
+
+const mockProjects: Project[] = [
+  {
+    id: "1",
+    name: "Website Redesign",
+    description: "Complete overhaul of the company website",
+    status: "active",
+    progress: 65,
+    dueDate: "2026-03-15",
+    createdAt: "2026-01-10",
+    updatedAt: "2026-02-10",
+    owner: {
+      id: "1",
+      name: "Alex Chen",
+      email: "alex@nexus.dev",
+      role: "Product Manager",
+      avatar: "AC",
+    },
+    members: [
+      { id: "1", name: "Alex Chen", email: "alex@nexus.dev", role: "Product Manager", avatar: "AC" },
+    ],
+    tasks: [
+      { id: "1", title: "Design mockups", completed: true, status: "done", priority: "high", dueDate: "2026-03-01" },
+      { id: "2", title: "Frontend dev", completed: false, status: "in-progress", priority: "medium", dueDate: "2026-03-05" },
+    ],
+  },
+  {
+    id: "2",
+    name: "Mobile App",
+    description: "Build mobile application",
+    status: "active",
+    progress: 40,
+    dueDate: "2026-04-30",
+    createdAt: "2026-01-15",
+    updatedAt: "2026-02-08",
+    owner: {
+      id: "2",
+      name: "Sarah Johnson",
+      email: "sarah@nexus.dev",
+      role: "Senior Developer",
+      avatar: "SJ",
+    },
+    members: [
+      { id: "2", name: "Sarah Johnson", email: "sarah@nexus.dev", role: "Senior Developer", avatar: "SJ" },
+    ],
+    tasks: [
+      { id: "3", title: "API development", completed: true, status: "done", priority: "high", dueDate: "2026-03-20" },
+    ],
+  },
+];
+
+describe("CalendarView", () => {
+  const mockProjectClick = jest.fn();
+  const mockTaskClick = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders calendar with correct month and year", () => {
+    render(
+      <CalendarView
+        projects={mockProjects}
+        onProjectClick={mockProjectClick}
+        onTaskClick={mockTaskClick}
+      />
+    );
+
+    // Check that the month/year header is displayed
+    const date = new Date();
+    const expectedMonthYear = date.toLocaleDateString("en-US", {
+      month: "long",
+      year: "numeric",
+    });
+    expect(screen.getByText(expectedMonthYear)).toBeInTheDocument();
+  });
+
+  it("displays weekday headers", () => {
+    render(<CalendarView projects={mockProjects} />);
+
+    const weekdays = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+    weekdays.forEach((day) => {
+      expect(screen.getByText(day)).toBeInTheDocument();
+    });
+  });
+
+  it("displays projects on their due dates", () => {
+    render(<CalendarView projects={mockProjects} />);
+
+    // Navigate to March 2026
+    const nextButton = screen.getByLabelText("Next month");
+    // Click multiple times to get to March 2026
+    for (let i = 0; i < 10; i++) {
+      fireEvent.click(nextButton);
+    }
+
+    // Look for project names in the calendar
+    expect(screen.getByText("Website Redesign")).toBeInTheDocument();
+  });
+
+  it("displays tasks on their due dates", () => {
+    render(<CalendarView projects={mockProjects} />);
+
+    // Navigate to March 2026
+    const nextButton = screen.getByLabelText("Next month");
+    for (let i = 0; i < 10; i++) {
+      fireEvent.click(nextButton);
+    }
+
+    // Look for task titles
+    expect(screen.getByText("Design mockups")).toBeInTheDocument();
+    expect(screen.getByText("Frontend dev")).toBeInTheDocument();
+  });
+
+  it("calls onProjectClick when a project is clicked", async () => {
+    render(
+      <CalendarView
+        projects={mockProjects}
+        onProjectClick={mockProjectClick}
+        onTaskClick={mockTaskClick}
+      />
+    );
+
+    // Navigate to March 2026
+    const nextButton = screen.getByLabelText("Next month");
+    for (let i = 0; i < 10; i++) {
+      fireEvent.click(nextButton);
+    }
+
+    // Find and click on a project
+    const projectElement = screen.getByText("Website Redesign");
+    fireEvent.click(projectElement);
+
+    await waitFor(() => {
+      expect(mockProjectClick).toHaveBeenCalledWith(mockProjects[0]);
+    });
+  });
+
+  it("navigates to previous month when clicking previous button", () => {
+    render(<CalendarView projects={mockProjects} />);
+
+    const prevButton = screen.getByLabelText("Previous month");
+    fireEvent.click(prevButton);
+
+    // The month should have changed
+    const currentDate = new Date();
+    const prevMonth = new Date(currentDate.getFullYear(), currentDate.getMonth() - 1);
+    const expectedMonthYear = prevMonth.toLocaleDateString("en-US", {
+      month: "long",
+      year: "numeric",
+    });
+    expect(screen.getByText(expectedMonthYear)).toBeInTheDocument();
+  });
+
+  it("navigates to next month when clicking next button", () => {
+    render(<CalendarView projects={mockProjects} />);
+
+    const nextButton = screen.getByLabelText("Next month");
+    fireEvent.click(nextButton);
+
+    // The month should have changed
+    const currentDate = new Date();
+    const nextMonth = new Date(currentDate.getFullYear(), currentDate.getMonth() + 1);
+    const expectedMonthYear = nextMonth.toLocaleDateString("en-US", {
+      month: "long",
+      year: "numeric",
+    });
+    expect(screen.getByText(expectedMonthYear)).toBeInTheDocument();
+  });
+
+  it("navigates to today when clicking today button", () => {
+    render(<CalendarView projects={mockProjects} />);
+
+    // First navigate to a different month
+    const nextButton = screen.getByLabelText("Next month");
+    fireEvent.click(nextButton);
+    fireEvent.click(nextButton);
+
+    // Then click today
+    const todayButton = screen.getByText("Today");
+    fireEvent.click(todayButton);
+
+    // Should be back to current month
+    const currentDate = new Date();
+    const expectedMonthYear = currentDate.toLocaleDateString("en-US", {
+      month: "long",
+      year: "numeric",
+    });
+    expect(screen.getByText(expectedMonthYear)).toBeInTheDocument();
+  });
+
+  it("displays legend with correct status colors", () => {
+    render(<CalendarView projects={mockProjects} />);
+
+    expect(screen.getByText("Project")).toBeInTheDocument();
+    expect(screen.getByText("To Do")).toBeInTheDocument();
+    expect(screen.getByText("In Progress")).toBeInTheDocument();
+    expect(screen.getByText("In Review")).toBeInTheDocument();
+    expect(screen.getByText("Done")).toBeInTheDocument();
+  });
+
+  it("shows item count badge for days with multiple items", () => {
+    render(<CalendarView projects={mockProjects} />);
+
+    // Navigate to March 2026 where we have multiple items on March 15
+    const nextButton = screen.getByLabelText("Next month");
+    for (let i = 0; i < 10; i++) {
+      fireEvent.click(nextButton);
+    }
+
+    // Look for the badge showing "2" (Website Redesign project + tasks on that day or close to it)
+    const badges = screen.getAllByText("2");
+    expect(badges.length).toBeGreaterThan(0);
+  });
+
+  it("renders empty state when no projects provided", () => {
+    render(<CalendarView projects={[]} />);
+
+    // Should still render the calendar grid
+    expect(screen.getByText("Sun")).toBeInTheDocument();
+    expect(screen.getByText("Today")).toBeInTheDocument();
+  });
+
+  it("is keyboard accessible", () => {
+    render(<CalendarView projects={mockProjects} />);
+
+    // Get all day cells
+    const dayCells = screen.getAllByRole("button", { name: /\d{1,2}/ });
+    expect(dayCells.length).toBeGreaterThan(0);
+
+    // Test that day cells are focusable
+    const firstDayCell = dayCells[0];
+    firstDayCell.focus();
+    expect(document.activeElement).toBe(firstDayCell);
+  });
+});

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -50,6 +50,7 @@ import { CreateProjectDialog } from "./create-project-dialog";
 import { EditProjectDialog } from "./edit-project-dialog";
 import { ProjectDetailDialog } from "./project-detail-dialog";
 import { KanbanBoard } from "@/components/kanban-board";
+import { CalendarView } from "@/components/calendar-view";
 import { getStatusColor, getStatusBadgeVariant } from "@/lib/projects/data";
 import { toast } from "sonner";
 import { useNotifications } from "@/lib/notifications";
@@ -90,7 +91,7 @@ export default function ProjectsPage() {
   const [isCreateOpen, setIsCreateOpen] = useState(false);
   const [editingProject, setEditingProject] = useState<Project | null>(null);
   const [viewingProject, setViewingProject] = useState<Project | null>(null);
-  const [viewMode, setViewMode] = useState<"list" | "kanban">("list");
+  const [viewMode, setViewMode] = useState<"list" | "kanban" | "calendar">("list");
   const [kanbanProjectId, setKanbanProjectId] = useState<string | null>(null);
 
   const activeProjects = projects.filter((p) => p.status === "active").length;
@@ -300,7 +301,7 @@ export default function ProjectsPage() {
         </div>
         <div className="flex gap-2">
           {/* View Mode Toggle */}
-          {viewMode === "kanban" && kanbanProject && (
+          {(viewMode === "kanban" || viewMode === "calendar") && (
             <Button
               variant="outline"
               size="sm"
@@ -329,7 +330,7 @@ export default function ProjectsPage() {
             <Button
               variant={viewMode === "kanban" ? "secondary" : "ghost"}
               size="sm"
-              className="rounded-l-none"
+              className="rounded-none"
               disabled={viewMode === "kanban" && !kanbanProject}
               onClick={() => {
                 if (projects.length > 0 && !kanbanProjectId) {
@@ -340,6 +341,18 @@ export default function ProjectsPage() {
             >
               <LayoutGrid className="mr-2 h-4 w-4" />
               Board
+            </Button>
+            <Button
+              variant={viewMode === "calendar" ? "secondary" : "ghost"}
+              size="sm"
+              className="rounded-l-none"
+              onClick={() => {
+                setViewMode("calendar");
+                setKanbanProjectId(null);
+              }}
+            >
+              <Calendar className="mr-2 h-4 w-4" />
+              Calendar
             </Button>
           </div>
           <Select
@@ -381,7 +394,26 @@ export default function ProjectsPage() {
       </motion.div>
 
       {/* View Mode Content */}
-      {viewMode === "kanban" && kanbanProject ? (
+      {viewMode === "calendar" ? (
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          className="space-y-4"
+        >
+          <div className="flex items-center justify-between">
+            <div>
+              <h2 className="text-xl font-semibold">Calendar View</h2>
+              <p className="text-sm text-muted-foreground">
+                View projects and tasks by their due dates
+              </p>
+            </div>
+          </div>
+          <CalendarView
+            projects={projects}
+            onProjectClick={(project) => setViewingProject(project)}
+          />
+        </motion.div>
+      ) : viewMode === "kanban" && kanbanProject ? (
         <motion.div
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}

--- a/components/calendar-view.tsx
+++ b/components/calendar-view.tsx
@@ -1,0 +1,318 @@
+"use client";
+
+import React, { useState, useMemo } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import {
+  ChevronLeft,
+  ChevronRight,
+  Calendar as CalendarIcon,
+  CheckSquare,
+  Folder,
+} from "lucide-react";
+import {
+  format,
+  startOfMonth,
+  endOfMonth,
+  startOfWeek,
+  endOfWeek,
+  addDays,
+  isSameMonth,
+  isSameDay,
+  addMonths,
+  subMonths,
+  isToday,
+  parseISO,
+} from "date-fns";
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { Project, Task } from "@/lib/projects/types";
+import { getStatusColor } from "@/lib/projects/data";
+
+interface CalendarViewProps {
+  projects: Project[];
+  onProjectClick?: (project: Project) => void;
+  onTaskClick?: (projectId: string, task: Task) => void;
+}
+
+type CalendarItem =
+  | { type: "project"; data: Project }
+  | { type: "task"; data: Task; projectId: string; projectName: string };
+
+export function CalendarView({
+  projects,
+  onProjectClick,
+  onTaskClick,
+}: CalendarViewProps) {
+  const [currentDate, setCurrentDate] = useState(new Date());
+  const [selectedDate, setSelectedDate] = useState<Date | null>(null);
+
+  const calendarItems = useMemo(() => {
+    const items: Map<string, CalendarItem[]> = new Map();
+
+    projects.forEach((project) => {
+      // Add project due date
+      const projectDate = project.dueDate;
+      if (!items.has(projectDate)) {
+        items.set(projectDate, []);
+      }
+      items.get(projectDate)!.push({ type: "project", data: project });
+
+      // Add task due dates
+      project.tasks.forEach((task) => {
+        if (task.dueDate) {
+          if (!items.has(task.dueDate)) {
+            items.set(task.dueDate, []);
+          }
+          items.get(task.dueDate)!.push({
+            type: "task",
+            data: task,
+            projectId: project.id,
+            projectName: project.name,
+          });
+        }
+      });
+    });
+
+    return items;
+  }, [projects]);
+
+  const monthStart = startOfMonth(currentDate);
+  const monthEnd = endOfMonth(monthStart);
+  const calendarStart = startOfWeek(monthStart);
+  const calendarEnd = endOfWeek(monthEnd);
+
+  const days: Date[] = [];
+  let day = calendarStart;
+  while (day <= calendarEnd) {
+    days.push(day);
+    day = addDays(day, 1);
+  }
+
+  const weekDays = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+
+  const handlePrevMonth = () => setCurrentDate(subMonths(currentDate, 1));
+  const handleNextMonth = () => setCurrentDate(addMonths(currentDate, 1));
+  const handleToday = () => setCurrentDate(new Date());
+
+  const formatDateKey = (date: Date) => format(date, "yyyy-MM-dd");
+
+  const getItemsForDate = (date: Date): CalendarItem[] => {
+    return calendarItems.get(formatDateKey(date)) || [];
+  };
+
+  return (
+    <TooltipProvider delayDuration={200}>
+      <div className="space-y-4">
+        {/* Calendar Header */}
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <h2 className="text-xl font-semibold">
+              {format(currentDate, "MMMM yyyy")}
+            </h2>
+            <div className="flex items-center gap-1">
+              <Button
+                variant="outline"
+                size="icon"
+                onClick={handlePrevMonth}
+                className="h-8 w-8"
+                aria-label="Previous month"
+              >
+                <ChevronLeft className="h-4 w-4" />
+              </Button>
+              <Button
+                variant="outline"
+                size="icon"
+                onClick={handleNextMonth}
+                className="h-8 w-8"
+                aria-label="Next month"
+              >
+                <ChevronRight className="h-4 w-4" />
+              </Button>
+            </div>
+          </div>
+          <Button variant="outline" size="sm" onClick={handleToday}>
+            <CalendarIcon className="mr-2 h-4 w-4" />
+            Today
+          </Button>
+        </div>
+
+        {/* Calendar Grid */}
+        <div className="rounded-lg border bg-card">
+          {/* Weekday Headers */}
+          <div className="grid grid-cols-7 border-b">
+            {weekDays.map((weekDay) => (
+              <div
+                key={weekDay}
+                className="py-2 text-center text-sm font-medium text-muted-foreground"
+              >
+                {weekDay}
+              </div>
+            ))}
+          </div>
+
+          {/* Calendar Days */}
+          <div className="grid grid-cols-7">
+            {days.map((date, index) => {
+              const dateKey = formatDateKey(date);
+              const items = getItemsForDate(date);
+              const isCurrentMonth = isSameMonth(date, currentDate);
+              const isTodayDate = isToday(date);
+              const isSelected = selectedDate && isSameDay(date, selectedDate);
+
+              return (
+                <motion.div
+                  key={dateKey}
+                  initial={{ opacity: 0, scale: 0.9 }}
+                  animate={{ opacity: 1, scale: 1 }}
+                  transition={{ delay: index * 0.005 }}
+                  className={cn(
+                    "min-h-[100px] border-b border-r p-2 transition-colors hover:bg-muted/50",
+                    !isCurrentMonth && "bg-muted/30 text-muted-foreground",
+                    index % 7 === 6 && "border-r-0",
+                    index >= days.length - 7 && "border-b-0"
+                  )}
+                  onClick={() => setSelectedDate(date)}
+                  role="button"
+                  tabIndex={0}
+                  aria-label={format(date, "MMMM d, yyyy")}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      setSelectedDate(date);
+                    }
+                  }}
+                >
+                  <div className="flex items-center justify-between">
+                    <span
+                      className={cn(
+                        "text-sm font-medium",
+                        isTodayDate &&
+                          "flex h-6 w-6 items-center justify-center rounded-full bg-primary text-primary-foreground"
+                      )}
+                    >
+                      {format(date, "d")}
+                    </span>
+                    {items.length > 0 && (
+                      <Badge variant="secondary" className="text-[10px] px-1">
+                        {items.length}
+                      </Badge>
+                    )}
+                  </div>
+
+                  {/* Calendar Items */}
+                  <div className="mt-1 space-y-1">
+                    <AnimatePresence>
+                      {items.slice(0, 3).map((item, idx) => (
+                        <Tooltip key={`${item.type}-${idx}`}>
+                          <TooltipTrigger asChild>
+                            <motion.div
+                              initial={{ opacity: 0, y: -5 }}
+                              animate={{ opacity: 1, y: 0 }}
+                              exit={{ opacity: 0, y: -5 }}
+                              className={cn(
+                                "cursor-pointer rounded px-1.5 py-0.5 text-[10px] font-medium truncate transition-colors hover:opacity-80",
+                                item.type === "project"
+                                  ? "bg-primary/10 text-primary border border-primary/20"
+                                  : item.data.status === "done"
+                                  ? "bg-emerald-500/10 text-emerald-600 border border-emerald-500/20"
+                                  : item.data.status === "in-progress"
+                                  ? "bg-blue-500/10 text-blue-600 border border-blue-500/20"
+                                  : item.data.status === "in-review"
+                                  ? "bg-amber-500/10 text-amber-600 border border-amber-500/20"
+                                  : "bg-slate-500/10 text-slate-600 border border-slate-500/20"
+                              )}
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                if (item.type === "project") {
+                                  onProjectClick?.(item.data);
+                                } else {
+                                  onTaskClick?.(item.projectId, item.data);
+                                }
+                              }}
+                            >
+                              {item.type === "project" ? (
+                                <span className="flex items-center gap-1">
+                                  <Folder className="h-3 w-3" />
+                                  {item.data.name}
+                                </span>
+                              ) : (
+                                <span className="flex items-center gap-1">
+                                  <CheckSquare className="h-3 w-3" />
+                                  {item.data.title}
+                                </span>
+                              )}
+                            </motion.div>
+                          </TooltipTrigger>
+                          <TooltipContent side="top" className="max-w-xs">
+                            <div className="space-y-1">
+                              <p className="font-medium">
+                                {item.type === "project"
+                                  ? item.data.name
+                                  : item.data.title}
+                              </p>
+                              {item.type === "task" && (
+                                <p className="text-xs text-muted-foreground">
+                                  Project: {item.projectName}
+                                </p>
+                              )}
+                              <p className="text-xs text-muted-foreground">
+                                Status: {" "}
+                                {item.type === "project"
+                                  ? item.data.status
+                                  : item.data.status.replace("-", " ")}
+                              </p>
+                              {item.type === "project" && (
+                                <p className="text-xs text-muted-foreground">
+                                  Progress: {item.data.progress}%
+                                </p>
+                              )}
+                            </div>
+                          </TooltipContent>
+                        </Tooltip>
+                      ))}
+                    </AnimatePresence>
+                    {items.length > 3 && (
+                      <p className="text-[10px] text-muted-foreground text-center">
+                        +{items.length - 3} more
+                      </p>
+                    )}
+                  </div>
+                </motion.div>
+              );
+            })}
+          </div>
+        </div>
+
+        {/* Legend */}
+        <div className="flex flex-wrap items-center gap-4 text-sm text-muted-foreground">
+          <div className="flex items-center gap-1.5">
+            <div className="h-3 w-3 rounded bg-primary/10 border border-primary/20" />
+            <span>Project</span>
+          </div>
+          <div className="flex items-center gap-1.5">
+            <div className="h-3 w-3 rounded bg-slate-500/10 border border-slate-500/20" />
+            <span>To Do</span>
+          </div>
+          <div className="flex items-center gap-1.5">
+            <div className="h-3 w-3 rounded bg-blue-500/10 border border-blue-500/20" />
+            <span>In Progress</span>
+          </div>
+          <div className="flex items-center gap-1.5">
+            <div className="h-3 w-3 rounded bg-amber-500/10 border border-amber-500/20" />
+            <span>In Review</span>
+          </div>
+          <div className="flex items-center gap-1.5">
+            <div className="h-3 w-3 rounded bg-emerald-500/10 border border-emerald-500/20" />
+            <span>Done</span>
+          </div>
+        </div>
+      </div>
+    </TooltipProvider>
+  );
+}

--- a/lib/projects/data.ts
+++ b/lib/projects/data.ts
@@ -23,10 +23,10 @@ export const initialProjects: Project[] = [
       { id: "2", name: "Sarah Johnson", email: "sarah@nexus.dev", role: "Senior Developer", avatar: "SJ" },
     ],
     tasks: [
-      { id: "1", title: "Design mockups", completed: true, status: "done", priority: "high" },
-      { id: "2", title: "Frontend development", completed: true, status: "done", priority: "medium" },
-      { id: "3", title: "Backend integration", completed: false, assignedTo: "2", status: "in-progress", priority: "high" },
-      { id: "4", title: "Content migration", completed: false, status: "todo", priority: "low" },
+      { id: "1", title: "Design mockups", completed: true, status: "done", priority: "high", dueDate: "2026-03-01" },
+      { id: "2", title: "Frontend development", completed: true, status: "done", priority: "medium", dueDate: "2026-03-05" },
+      { id: "3", title: "Backend integration", completed: false, assignedTo: "2", status: "in-progress", priority: "high", dueDate: "2026-03-10" },
+      { id: "4", title: "Content migration", completed: false, status: "todo", priority: "low", dueDate: "2026-03-12" },
     ],
   },
   {
@@ -50,10 +50,10 @@ export const initialProjects: Project[] = [
       { id: "5", name: "Tom Wilson", email: "tom@nexus.dev", role: "Backend Developer", avatar: "TW" },
     ],
     tasks: [
-      { id: "1", title: "UI/UX design", completed: true, status: "done", priority: "high" },
-      { id: "2", title: "API development", completed: true, assignedTo: "5", status: "done", priority: "high" },
-      { id: "3", title: "App development", completed: false, assignedTo: "2", status: "in-progress", priority: "medium" },
-      { id: "4", title: "Testing", completed: false, status: "todo", priority: "low" },
+      { id: "1", title: "UI/UX design", completed: true, status: "done", priority: "high", dueDate: "2026-03-15" },
+      { id: "2", title: "API development", completed: true, assignedTo: "5", status: "done", priority: "high", dueDate: "2026-03-20" },
+      { id: "3", title: "App development", completed: false, assignedTo: "2", status: "in-progress", priority: "medium", dueDate: "2026-04-01" },
+      { id: "4", title: "Testing", completed: false, status: "todo", priority: "low", dueDate: "2026-04-10" },
     ],
   },
   {
@@ -77,10 +77,10 @@ export const initialProjects: Project[] = [
       { id: "6", name: "Jessica Brown", email: "jessica@nexus.dev", role: "Data Analyst", avatar: "JB" },
     ],
     tasks: [
-      { id: "1", title: "Strategy planning", completed: true, status: "done", priority: "medium" },
-      { id: "2", title: "Content creation", completed: true, status: "done", priority: "low" },
-      { id: "3", title: "Campaign execution", completed: true, status: "done", priority: "high" },
-      { id: "4", title: "Performance analysis", completed: true, assignedTo: "6", status: "done", priority: "low" },
+      { id: "1", title: "Strategy planning", completed: true, status: "done", priority: "medium", dueDate: "2026-01-10" },
+      { id: "2", title: "Content creation", completed: true, status: "done", priority: "low", dueDate: "2026-01-15" },
+      { id: "3", title: "Campaign execution", completed: true, status: "done", priority: "high", dueDate: "2026-01-20" },
+      { id: "4", title: "Performance analysis", completed: true, assignedTo: "6", status: "done", priority: "low", dueDate: "2026-01-25" },
     ],
   },
   {
@@ -104,10 +104,10 @@ export const initialProjects: Project[] = [
       { id: "6", name: "Jessica Brown", email: "jessica@nexus.dev", role: "Data Analyst", avatar: "JB" },
     ],
     tasks: [
-      { id: "1", title: "Data audit", completed: true, status: "done", priority: "high" },
-      { id: "2", title: "Schema design", completed: true, status: "done", priority: "medium" },
-      { id: "3", title: "Migration scripts", completed: false, status: "in-progress", priority: "high" },
-      { id: "4", title: "Testing", completed: false, status: "todo", priority: "medium" },
+      { id: "1", title: "Data audit", completed: true, status: "done", priority: "high", dueDate: "2026-04-15" },
+      { id: "2", title: "Schema design", completed: true, status: "done", priority: "medium", dueDate: "2026-04-20" },
+      { id: "3", title: "Migration scripts", completed: false, status: "in-progress", priority: "high", dueDate: "2026-05-01" },
+      { id: "4", title: "Testing", completed: false, status: "todo", priority: "medium", dueDate: "2026-05-10" },
     ],
   },
   {


### PR DESCRIPTION
Implements a calendar view component that displays projects and tasks
by their due dates. This provides users with a timeline-based perspective
of their work, complementing the existing list and Kanban board views.

Features:
- Month view calendar with navigation (previous/next month, today)
- Visual distinction between projects and tasks
- Color-coded status indicators (todo, in-progress, in-review, done)
- Tooltips showing detailed information on hover
- Click to view project/task details
- Keyboard accessible
- Fully responsive design
- Comprehensive test coverage

Technical changes:
- New CalendarView component with date-fns integration
- Added 'Calendar' tab to Projects page
- Updated task data to include due dates
- Full test suite with 12 test cases

Closes #39
