### PR TITLE
Fix failing tests: AuthProvider mocking and form accessibility

### DIFF
--- a/__tests__/app/team/add-team-member-dialog.test.tsx
+++ b/__tests__/app/team/add-team-member-dialog.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { AddTeamMemberDialog } from '@/app/team/add-team-member-dialog'
 
@@ -19,11 +19,6 @@ describe('AddTeamMemberDialog', () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
-    jest.useFakeTimers()
-  })
-
-  afterEach(() => {
-    jest.useRealTimers()
   })
 
   const renderDialog = (props = {}) => {
@@ -166,9 +161,7 @@ describe('AddTeamMemberDialog', () => {
     const submitBtn = screen.getByRole('button', { name: /add member/i })
     await userEvent.click(submitBtn)
     
-    // Wait for async operations
-    jest.advanceTimersByTime(500)
-    
+    // Wait for the async submit (500ms timeout in component)
     await waitFor(() => {
       expect(mockOnSubmit).toHaveBeenCalledWith({
         name: 'John Doe',
@@ -178,7 +171,7 @@ describe('AddTeamMemberDialog', () => {
         location: 'New York, NY',
         avatar: 'JD',
       })
-    })
+    }, { timeout: 3000 })
     
     expect(toast.success).toHaveBeenCalledWith('Team member "John Doe" added successfully')
     expect(mockOnOpenChange).toHaveBeenCalledWith(false)
@@ -199,15 +192,13 @@ describe('AddTeamMemberDialog', () => {
     const submitBtn = screen.getByRole('button', { name: /add member/i })
     await userEvent.click(submitBtn)
     
-    jest.advanceTimersByTime(500)
-    
     await waitFor(() => {
       expect(mockOnSubmit).toHaveBeenCalledWith(
         expect.objectContaining({
           avatar: 'MJ',
         })
       )
-    })
+    }, { timeout: 3000 })
   })
 
   it('allows changing status to offline', async () => {
@@ -234,15 +225,13 @@ describe('AddTeamMemberDialog', () => {
     const submitBtn = screen.getByRole('button', { name: /add member/i })
     await userEvent.click(submitBtn)
     
-    jest.advanceTimersByTime(500)
-    
     await waitFor(() => {
       expect(mockOnSubmit).toHaveBeenCalledWith(
         expect.objectContaining({
           status: 'offline',
         })
       )
-    })
+    }, { timeout: 3000 })
   })
 
   it('shows loading state during submission', async () => {
@@ -286,12 +275,10 @@ describe('AddTeamMemberDialog', () => {
     const submitBtn = screen.getByRole('button', { name: /add member/i })
     await userEvent.click(submitBtn)
     
-    jest.advanceTimersByTime(500)
-    
     // Dialog should close, so we check the onOpenChange was called
     await waitFor(() => {
       expect(mockOnOpenChange).toHaveBeenCalledWith(false)
-    })
+    }, { timeout: 3000 })
   })
 
   it('resets form and errors when dialog is reopened', async () => {

--- a/__tests__/app/team/page.test.tsx
+++ b/__tests__/app/team/page.test.tsx
@@ -19,14 +19,29 @@ jest.mock('framer-motion', () => ({
   },
 }))
 
+// Mock useAuth hook
+jest.mock('@/lib/auth', () => ({
+  useAuth: () => ({
+    user: {
+      id: '1',
+      email: 'admin@nexus.dev',
+      name: 'Admin User',
+      role: 'admin',
+    },
+    isAuthenticated: true,
+    isLoading: false,
+    login: jest.fn(),
+    logout: jest.fn(),
+    error: null,
+    clearError: jest.fn(),
+    updateUserRole: jest.fn(),
+  }),
+  AuthProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+
 describe('TeamPage', () => {
   beforeEach(() => {
     jest.clearAllMocks()
-    jest.useFakeTimers()
-  })
-
-  afterEach(() => {
-    jest.useRealTimers()
   })
 
   it('renders team page with header', () => {
@@ -119,13 +134,10 @@ describe('TeamPage', () => {
     const submitBtn = screen.getByRole('button', { name: /add member/i })
     await userEvent.click(submitBtn)
     
-    // Wait for async operations
-    jest.advanceTimersByTime(500)
-    
-    // Dialog should close
+    // Dialog should close (wait for async submit)
     await waitFor(() => {
       expect(screen.queryByText('Add Team Member')).not.toBeInTheDocument()
-    })
+    }, { timeout: 3000 })
     
     // New member should appear in the list
     await waitFor(() => {
@@ -137,7 +149,7 @@ describe('TeamPage', () => {
       const totalMembersElements = screen.getAllByText('7')
       expect(totalMembersElements.length).toBeGreaterThan(0)
     })
-  })
+  }, 15000)
 
   it('updates active members count when adding active member', async () => {
     render(<TeamPage />)
@@ -161,14 +173,12 @@ describe('TeamPage', () => {
     const submitBtn = screen.getByRole('button', { name: /add member/i })
     await userEvent.click(submitBtn)
     
-    jest.advanceTimersByTime(500)
-    
     // Active count should update (was 5, now should be 6)
     await waitFor(() => {
       const activeElements = screen.getAllByText('6')
       expect(activeElements.length).toBeGreaterThan(0)
-    })
-  })
+    }, { timeout: 3000 })
+  }, 15000)
 
   it('renders team activity section', () => {
     render(<TeamPage />)
@@ -205,13 +215,11 @@ describe('TeamPage', () => {
     const submitBtn = screen.getByRole('button', { name: /add member/i })
     await userEvent.click(submitBtn)
     
-    jest.advanceTimersByTime(500)
-    
     // New member should be added successfully
     await waitFor(() => {
       expect(screen.getByText('Test User')).toBeInTheDocument()
-    })
-  })
+    }, { timeout: 3000 })
+  }, 15000)
 
   it('sets correct default values for new member', async () => {
     render(<TeamPage />)
@@ -233,14 +241,12 @@ describe('TeamPage', () => {
     const submitBtn = screen.getByRole('button', { name: /add member/i })
     await userEvent.click(submitBtn)
     
-    jest.advanceTimersByTime(500)
-    
     // New member should appear with correct role and location
     await waitFor(() => {
       expect(screen.getByText('Bob Wilson')).toBeInTheDocument()
       expect(screen.getByText('Data Analyst')).toBeInTheDocument()
-    })
-  })
+    }, { timeout: 3000 })
+  }, 15000)
 
   it('shows percentage calculation in Active Now card', () => {
     render(<TeamPage />)

--- a/app/team/add-team-member-dialog.tsx
+++ b/app/team/add-team-member-dialog.tsx
@@ -247,7 +247,7 @@ export function AddTeamMemberDialog({
                 setFormData({ ...formData, status: value as "active" | "offline" })
               }
             >
-              <SelectTrigger>
+              <SelectTrigger id="status">
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>


### PR DESCRIPTION
- Add id="status" to SelectTrigger in AddTeamMemberDialog for proper label association
- Mock useAuth hook in TeamPage tests to prevent 'useAuth must be used within an AuthProvider' errors
- Remove jest.useFakeTimers from tests to prevent timeout issues with user-event
- Add proper timeout values to waitFor calls
- Fix test timeouts by extending to 15s for async operations
